### PR TITLE
Fix BERT-based seat scoring function

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -124,7 +124,6 @@ dependencies:
     - pytest==4.3.0
     - python-dateutil==2.8.0
     - python-jose==2.0.2
-    - pytorch-pretrained-bert==0.6.1
     - pytz==2017.3
     - pyyaml==3.13
     - regex==2019.2.21
@@ -142,6 +141,7 @@ dependencies:
     - sqlparse==0.2.4
     - tensorboardx==1.2
     - tensorflow-hub==0.3.0
+    - transformers==3.2.0
     - thinc==6.12.1
     - toolz==0.9.0
     - tqdm==4.31.1

--- a/sentbias/encoders/bert.py
+++ b/sentbias/encoders/bert.py
@@ -1,12 +1,12 @@
 ''' Convenience functions for handling BERT '''
 import torch
-import pytorch_pretrained_bert as bert
+from transformers import AutoTokenizer, AutoModel
 
 
 def load_model(version='bert-large-uncased'):
     ''' Load BERT model and corresponding tokenizer '''
-    tokenizer = bert.BertTokenizer.from_pretrained(version)
-    model = bert.BertModel.from_pretrained(version)
+    tokenizer = AutoTokenizer.from_pretrained(version)
+    model = AutoModel.from_pretrained(version)
     model.eval()
 
     return model, tokenizer
@@ -16,12 +16,11 @@ def encode(model, tokenizer, texts):
     ''' Use tokenizer and model to encode texts '''
     encs = {}
     for text in texts:
-        tokenized = tokenizer.tokenize(text)
-        indexed = tokenizer.convert_tokens_to_ids(tokenized)
-        segment_idxs = [0] * len(tokenized)
+        indexed = tokenizer.encode(text)
+        segment_idxs = [0] * len(indexed)
         tokens_tensor = torch.tensor([indexed])
         segments_tensor = torch.tensor([segment_idxs])
-        enc, _ = model(tokens_tensor, segments_tensor, output_all_encoded_layers=False)
+        enc, _ = model(tokens_tensor, token_type_ids=segments_tensor)
 
         enc = enc[:, 0, :]  # extract the last rep of the first input
         encs[text] = enc.detach().view(-1).numpy()


### PR DESCRIPTION
### What has been fixed?
- update transformers library to load BERT-large-cased model, correctly
- update code to use [cls]

### Results


Test | Context | BERT (prev) | BERT (new)
-- | -- | -- | --
C1: Flowers/Insects | word | 0.22 | -0.43
C1: Flowers/Insects | sent | 0.62 | 1.07
C3: EA/AA Names | word | −0.11 | 1.16
C3: EA/AA Names | sent | 0.05 | 0.57
C6: M/F Names, Career | word | 0.21 | 0.48
C6: M/F Names, Career | sent | 0.08 | -0.15
ABW Stereotype | word | −0.32 | 1.56
ABW Stereotype | sent | −0.17 | -0.54
Double Bind: Competent | word | −0.81 | 0.31
Double Bind: Competent | sent | 0.39 | -0.15
Double Bind: Competent | sent (u) | 1.17 | 0.45
Double Bind: Likable | word | −0.55 | -0.45
Double Bind: Likable | sent | −0.35 | 0.37
Double Bind: Likable | sent (u) | 0.99 | -0.05








resolves #1 